### PR TITLE
Add seurat globals option

### DIFF
--- a/posts/seurat-cosmx-basics/index.qmd
+++ b/posts/seurat-cosmx-basics/index.qmd
@@ -60,6 +60,10 @@ library(Seurat)
 library(ggplot2)
 ```
 
+Adjust globals option to avoid an error exceeding max allowed size. We've found this is necessary even with relatively small CosMx datasets (30 - 40 FOVs).
+```{r set_globals, message = FALSE, eval = FALSE}
+options(future.globals.maxSize = 8000 * 1024^2)
+```
 
 Load in the Seurat object, available on Box.com [here](https://nanostring.box.com/s/y7ielc54qw1g1f5x98hxczdo8tezobbg){target="_blank"}.
 ```{r load_seuratObject, message=FALSE, eval = FALSE}


### PR DESCRIPTION
When working with many CosMx datasets in Seurat, there is often an error thrown that the total size of globals needed for the future expression exceeds the maximum allowed size. Seurat uses parallelization for a number of functions by default for many functions and recommends in their vignette to increase this `future.globals.maxSize` option to avoid the errors.

![image](https://github.com/Nanostring-Biostats/CosMx-Analysis-Scratch-Space/assets/24260255/aa03e137-c392-4f15-bcf3-527cc8960e1c)


This PR adds the recommendation to increase the max size for this option.