### PR TITLE
google analytics info

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -20,6 +20,13 @@ website:
         href: https://www.linkedin.com/company/nanostring-technologies
       - icon: rss
         href: index.xml
+  cookie-consent:
+    type: implied
+    style: simple
+    palette: light
+  google-analytics:
+    tracking-id: "G-29W4MW0Y2W"
+    anonymize-ip: true
   page-footer:
     center:
       - text: "License"


### PR DESCRIPTION
Adding the Google Analytics info and cookie consent in the yaml allows us to track the popularity of posts which can help us gauge additional content people would like to see. IP addresses are anonymized and users can refine their user experience (see images below)

For more information: 

[https://quarto.org/docs/websites/website-tools.html#google-analytics](https://quarto.org/docs/websites/website-tools.html#google-analytics)

[https://quarto.org/docs/websites/website-tools.html#cookie-consent](https://quarto.org/docs/websites/website-tools.html#cookie-consent)


<img width="1431" alt="image" src="https://github.com/Nanostring-Biostats/CosMx-Analysis-Scratch-Space/assets/5805450/6d42bf51-ff7c-4e5d-bcac-f353f817903c">


If user selected "Change my preferences", they would be able to adjust them. For example:
<img width="746" alt="image" src="https://github.com/Nanostring-Biostats/CosMx-Analysis-Scratch-Space/assets/5805450/148d2510-7c5c-4fb2-9ba5-0a41a835ba60">

