### PR TITLE
Moved shared affiliations to meta yml

### DIFF
--- a/posts/_metadata.yml
+++ b/posts/_metadata.yml
@@ -14,10 +14,10 @@ affiliations:
     city: Seattle
     state: WA
   - id: patrickjdanaher
-    name: "Github: [@patrickjdanaher](https://github.com/patrickjdanaher)"
+    name: "Github: [@patrickjdanaher](https://github.com/patrickjdanaher){target='_blank'}"
   - id: lidanwu
-    name: "Github: [@lidanwu](https://github.com/lidanwu)"
+    name: "Github: [@lidanwu](https://github.com/lidanwu){target='_blank'}"
   - id: eveilyeverafter
-    name: "Github: [@eveilyeverafter](https://github.com/eveilyeverafter)"
+    name: "Github: [@eveilyeverafter](https://github.com/eveilyeverafter){target='_blank'}"
   - id: crwilliams11
     name: "Github: [@crwilliams11](https://github.com/crwilliams11){target='_blank'}"

--- a/posts/_metadata.yml
+++ b/posts/_metadata.yml
@@ -2,7 +2,22 @@
 
 # freeze computational output
 # (see https://quarto.org/docs/projects/code-execution.html#freeze)
-freeze: true
+freeze: false
 
 # Enable banner style title blocks
 title-block-banner: true
+
+# Author affiliations 
+affiliations:
+  - id: nstg
+    name: NanoString, a Bruker Company
+    city: Seattle
+    state: WA
+  - id: patrickjdanaher
+    name: "Github: [@patrickjdanaher](https://github.com/patrickjdanaher)"
+  - id: lidanwu
+    name: "Github: [@lidanwu](https://github.com/lidanwu)"
+  - id: eveilyeverafter
+    name: "Github: [@eveilyeverafter](https://github.com/eveilyeverafter)"
+  - id: crwilliams11
+    name: "Github: [@crwilliams11](https://github.com/crwilliams11){target='_blank'}"

--- a/posts/big-data/index.qmd
+++ b/posts/big-data/index.qmd
@@ -5,14 +5,6 @@ author:
     affiliations:
       - ref: nstg
       - ref: patrickjdanaher
-affiliations:
-  - id: nstg
-    name: NanoString Technologies, Inc.
-    city: Seattle
-    state: WA
-  - id: patrickjdanaher
-    name: "Github: [@patrickjdanaher](https://github.com/patrickjdanaher)"
-
 date: "2024-03-04"
 date-modified: "2024-04-17"
 categories: [big data]

--- a/posts/cell-typing-basics/index.qmd
+++ b/posts/cell-typing-basics/index.qmd
@@ -5,14 +5,6 @@ author:
     affiliations:
       - ref: nstg
       - ref: patrickjdanaher
-affiliations:
-  - id: nstg
-    name: NanoString Technologies, Inc.
-    city: Seattle
-    state: WA
-  - id: patrickjdanaher
-    name: "Github: [@patrickjdanaher](https://github.com/patrickjdanaher)"
-
 date: "2024-03-12"
 date-modified: "2024-04-17"
 categories: [cell typing]

--- a/posts/deriving-cell-polygons-from-transcript-locations/index.qmd
+++ b/posts/deriving-cell-polygons-from-transcript-locations/index.qmd
@@ -5,14 +5,6 @@ author:
     affiliations:
       - ref: nstg
       - ref: patrickjdanaher
-affiliations:
-  - id: nstg
-    name: NanoString Technologies, Inc.
-    city: Seattle
-    state: WA
-  - id: patrickjdanaher
-    name: "Github: [@patrickjdanaher](https://github.com/patrickjdanaher)"
-
 date: "2024-01-05"
 date-modified: "2024-04-17"
 categories: [visualization]

--- a/posts/high-plex-spatial/index.qmd
+++ b/posts/high-plex-spatial/index.qmd
@@ -5,14 +5,6 @@ author:
     affiliations:
       - ref: nstg
       - ref: patrickjdanaher
-affiliations:
-  - id: nstg
-    name: NanoString Technologies, Inc.
-    city: Seattle
-    state: WA
-  - id: patrickjdanaher
-    name: "Github: [@patrickjdanaher](https://github.com/patrickjdanaher)"
-
 date: "2024-01-05"
 date-modified: "2024-04-16"
 categories: [overview]

--- a/posts/normalization/index.qmd
+++ b/posts/normalization/index.qmd
@@ -5,14 +5,6 @@ author:
     affiliations:
       - ref: nstg
       - ref: patrickjdanaher
-affiliations:
-  - id: nstg
-    name: NanoString Technologies, Inc.
-    city: Seattle
-    state: WA
-  - id: patrickjdanaher
-    name: "Github: [@patrickjdanaher](https://github.com/patrickjdanaher)"
-
 date: "2024-01-29"
 date-modified: "2024-04-17"
 categories: [quality control, normalization, pre-processing]

--- a/posts/on-cell-typing-with-marker-genes/index.qmd
+++ b/posts/on-cell-typing-with-marker-genes/index.qmd
@@ -5,14 +5,6 @@ author:
     affiliations:
       - ref: nstg
       - ref: patrickjdanaher
-affiliations:
-  - id: nstg
-    name: NanoString Technologies, Inc.
-    city: Seattle
-    state: WA
-  - id: patrickjdanaher
-    name: "Github: [@patrickjdanaher](https://github.com/patrickjdanaher)"
-
 date: "2024-03-12"
 date-modified: "2024-04-17"
 categories: [cell typing]

--- a/posts/segmentation-error/index.qmd
+++ b/posts/segmentation-error/index.qmd
@@ -5,14 +5,6 @@ author:
     affiliations:
       - ref: nstg
       - ref: patrickjdanaher
-affiliations:
-  - id: nstg
-    name: NanoString Technologies, Inc.
-    city: Seattle
-    state: WA
-  - id: patrickjdanaher
-    name: "Github: [@patrickjdanaher](https://github.com/patrickjdanaher)"
-
 date: "2024-01-24"
 date-modified: "2024-04-17"
 categories: [segmentation]

--- a/posts/seurat-cosmx-basics/index.qmd
+++ b/posts/seurat-cosmx-basics/index.qmd
@@ -5,13 +5,6 @@ author:
     affiliations:
       - ref: nstg
       - ref: crwilliams11
-affiliations:
-  - id: nstg
-    name: NanoString Technologies, Inc.
-    city: Seattle
-    state: WA
-  - id: crwilliams11
-    name: "Github: [@crwilliams11](https://github.com/crwilliams11){target='_blank'}"
 toc: true
 toc-title: Contents
 toc-depth: 3

--- a/posts/using-napari-for-cosmx-data/index.qmd
+++ b/posts/using-napari-for-cosmx-data/index.qmd
@@ -5,13 +5,6 @@ author:
     affiliations: 
       - ref: nstg
       - ref: eveilyeverafter
-affiliations:
-  - id: nstg
-    name: NanoString Technologies, Inc.
-    city: Seattle
-    state: WA
-  - id: eveilyeverafter
-    name: "Github: [@eveilyeverafter](https://github.com/eveilyeverafter)"
 toc: true
 toc-title: Contents
 toc-depth: 3

--- a/posts/visualize-cellular-neighborhood-in-gallery-mode/index.qmd
+++ b/posts/visualize-cellular-neighborhood-in-gallery-mode/index.qmd
@@ -9,16 +9,6 @@ author:
     affiliations:
       - ref: nstg
       - ref: patrickjdanaher
-affiliations:
-  - id: nstg
-    name: NanoString Technologies, Inc.
-    city: Seattle
-    state: WA
-  - id: patrickjdanaher
-    name: "Github: [@patrickjdanaher](https://github.com/patrickjdanaher)"
-  - id: lidanwu
-    name: "Github: [@lidanwu](https://github.com/lidanwu)"
-
 date: "2024-01-24"
 date-modified: "2024-04-17"
 categories: [visualization, napari]

--- a/posts/visuals-reduce-whitespace/index.qmd
+++ b/posts/visuals-reduce-whitespace/index.qmd
@@ -5,14 +5,6 @@ author:
     affiliations:
       - ref: nstg
       - ref: patrickjdanaher
-affiliations:
-  - id: nstg
-    name: NanoString Technologies, Inc.
-    city: Seattle
-    state: WA
-  - id: patrickjdanaher
-    name: "Github: [@patrickjdanaher](https://github.com/patrickjdanaher)"
-
 date: "2024-01-26"
 date-modified: "2024-04-17"
 categories: [visualization]


### PR DESCRIPTION
Adding the author affiliations to each post is unnecessary. This small PR moves the shared content to the posts' metadata yaml file. 

It also changes the general default of freeze to false. Individual posts can change this if needed but currently we do not track the freeze directory. 

Adding @lidanwu as a reviewer since this may remove the need to adjust an element PR #31. 