### PR TITLE
update renv to add in reticulate

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -309,6 +309,51 @@
       ],
       "Hash": "d65e35823c817f09f4de424fcdfa812a"
     },
+    "here": {
+      "Package": "here",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "rprojroot"
+      ],
+      "Hash": "24b224366f9c2e7534d2344d10d59211"
+    },
+    "withr": {
+      "Package": "withr",
+      "Version": "3.0.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics"
+      ],
+      "Hash": "d31b6c62c10dcf11ec530ca6b0dd5d35"
+    },
+    "reticulate": {
+      "Package": "reticulate",
+      "Version": "1.36.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "Matrix",
+        "Rcpp",
+        "RcppTOML",
+        "graphics",
+        "here",
+        "jsonlite",
+        "methods",
+        "png",
+        "rappdirs",
+        "rlang",
+        "utils",
+        "withr"
+        
+      ],
+      "Hash": "ed42084db0ff8dd4b1d997202f774dcf"
+    },
     "sass": {
       "Package": "sass",
       "Version": "0.4.8",


### PR DESCRIPTION
The current site is not rendering properly due to lack of reticulate package to render the python code. This PR adds `reticulate` and its dependencies to the `renv.lock` file. 
Not sure how to test if it's working locally, so I would merge it to check it this fix the deploy issue online. 
If it doesn't, I would then change the code block type for all python code. 