### PR TITLE
updated [] to lists for cats

### DIFF
--- a/posts/GeoMx-scMask-generation/index.qmd
+++ b/posts/GeoMx-scMask-generation/index.qmd
@@ -15,7 +15,11 @@ number-sections: true
 number-depth: 4
 date: "2024-06-12"
 date-modified: last-modified
-categories: [GeoMx, how-tos, image processing, python]
+categories:
+  - GeoMx
+  - how-tos
+  - image processing
+  - python
 image: figures/workflow_GeoMx_scMask_given_query.png
 description: "This post introduces a pipeline for automatic generating GeoMx&#174; Digital Spatial Profiler (DSP)-ready binary masks in batch for marker-based single-cell application. Given the query marker protein of interest, the pipeline would take morphology images and generate binary masks for negative-stained cells and cells connecting to positive-stained regions, respectively. The pipeline runs as a command line and this post would serve as a guide to how it works and how to use it."
 draft: false

--- a/posts/background/index.qmd
+++ b/posts/background/index.qmd
@@ -8,7 +8,9 @@ author:
       - ref: patrickjdanaher
 date: "2024-08-21"
 date-modified: "2024-08-21"
-categories: [quality control, overview]
+categories:
+ - quality control
+ - overview
 draft: false
 image: figures/background_tile.png
 ---

--- a/posts/cell-typing-basics/index.qmd
+++ b/posts/cell-typing-basics/index.qmd
@@ -8,7 +8,8 @@ author:
       - ref: patrickjdanaher
 date: "2024-03-12"
 date-modified: "2024-04-17"
-categories: [cell typing]
+categories:
+  - cell typing
 draft: false
 ---
 

--- a/posts/cellular-neighborhoods/cellular-neighborhoods.qmd
+++ b/posts/cellular-neighborhoods/cellular-neighborhoods.qmd
@@ -17,24 +17,12 @@ toc-location: left
 number-sections: true
 number-depth: 4
 date: "2024-10-30"
-categories: [overview]
+categories: 
+  - overview
 draft: false
 image: figures/neighborhood-tile.png
 description: An introduction to "cellular neighborhoods" and their many uses in analysis. 
 code-fold: false
-# page-layout: full
-format: 
-  html:
-    theme: 
-      light: custom.scss
-      dark: darkly
-#   pdf:
-#     number-sections: true
-#   docx:
-#     toc: true
-#     number-sections: true
-#     highlight-style: github
-# format-links: [pdf, docx]
 ---
 
 

--- a/posts/composite-images/making-composite-images.qmd
+++ b/posts/composite-images/making-composite-images.qmd
@@ -18,7 +18,11 @@ toc-location: left
 number-sections: true
 number-depth: 4
 date: "2024-06-12"
-categories: [Squidpy, Giotto, pre-processing, python]
+categories:
+  - Squidpy
+  - Giotto
+  - pre-processing
+  - python
 draft: false
 image: figures/fig1.png
 description: In this post, we describe a developmental python

--- a/posts/deriving-cell-polygons-from-transcript-locations/index.qmd
+++ b/posts/deriving-cell-polygons-from-transcript-locations/index.qmd
@@ -8,7 +8,8 @@ author:
       - ref: patrickjdanaher
 date: "2024-01-05"
 date-modified: "2024-04-17"
-categories: [visualization]
+categories:
+  - visualization
 draft: false
 image: figures/fig1.png
 ---

--- a/posts/flat-file-exports/flat-files-compare.qmd
+++ b/posts/flat-file-exports/flat-files-compare.qmd
@@ -14,16 +14,12 @@ toc-location: left
 number-sections: true
 number-depth: 3
 date: "2024-07-03"
-categories: [flat files]
+categories:
+  - flat files
 draft: false
 image: figures/fig-fig1.png
 description: This short post shows differences between the AtoMx&#8482; SIP-exported and legacy CosMx<sup>&#174;</sup> SMI \"flat files\"
 code-fold: false
-format: 
-  html:
-    theme: 
-      light: custom.scss
-      dark: darkly
 google-scholar: true
 ---
 

--- a/posts/fov-qc/index.qmd
+++ b/posts/fov-qc/index.qmd
@@ -13,7 +13,9 @@ toc-expand: 2
 toc-location: left
 date: "2024-05-20"
 date-modified: "2024-05-20"
-categories: [quality control, pre-processing]
+categories:
+  - quality control
+  - pre-processing
 draft: false
 image: figures/fov_qc_thumbnail.png
 ---

--- a/posts/h5ad_conversion/index.qmd
+++ b/posts/h5ad_conversion/index.qmd
@@ -15,7 +15,12 @@ number-sections: true
 number-depth: 4
 date: "2024-06-05"
 date-modified: last-modified
-categories: [how-tos, visualization, Seurat, AnnData, python]
+categories:
+  - how-tos
+  - visualization 
+  - Seurat
+  - AnnData
+  - python
 image: figures/Fig-mBrain-S1-cirroViewer-screenshot.png
 description: "This post describes how to create anndata object from AtoMx&#8482; exported results. The resulting oject in '.h5ad' format could be further analyzed using various python-based single-cell analysis tools, like scanpy and squidpy. Non-coders could also share the light-weighted data object, visualize and explore the processed data in several open-sourced interactive viewers, like Cirrocumulus and CELLxGENE viewers. "
 draft: false

--- a/posts/high-plex-spatial/index.qmd
+++ b/posts/high-plex-spatial/index.qmd
@@ -8,7 +8,8 @@ author:
       - ref: patrickjdanaher
 date: "2024-01-05"
 date-modified: "2024-04-16"
-categories: [overview]
+categories:
+  - overview
 draft: false
 image: figures/fig3.png
 ---

--- a/posts/hybrid-reference-profiles/index.qmd
+++ b/posts/hybrid-reference-profiles/index.qmd
@@ -8,7 +8,8 @@ author:
       - ref: patrickjdanaher
 date: "2024-08-21"
 date-modified: "2024-08-21"
-categories: [cell typing]
+categories:
+  - cell typing
 draft: false
 image: figures/heatmap_tile.png
 description: "A short guide to creating reference profiles, and to merging profiles from different sources."

--- a/posts/insitucor/index.qmd
+++ b/posts/insitucor/index.qmd
@@ -8,7 +8,9 @@ author:
       - ref: patrickjdanaher
 date: "2024-07-18"
 date-modified: "2024-07-18"
-categories: [AtoMx modules, exploratory analysis]
+categories:
+  - AtoMx modules
+  - exploratory analysis
 draft: false
 image: figures/insitucor-tile.png
 ---

--- a/posts/insitudiff/index.qmd
+++ b/posts/insitudiff/index.qmd
@@ -8,7 +8,8 @@ author:
       - ref: patrickjdanaher
 date: "2024-11-25"
 date-modified: "2024-11-25"
-categories: [exploratory analysis]
+categories:
+  - exploratory analysis
 draft: false
 image: figures/insitudiff-tile.png
 description: Perturbation analysis of disease vs. control cellular neighborhoods.

--- a/posts/marker-gene-smoothing/index.qmd
+++ b/posts/marker-gene-smoothing/index.qmd
@@ -14,7 +14,9 @@ toc-location: left
 number-sections: true
 number-depth: 4
 date: "2024-06-19"
-categories: [visualization, cell typing]
+categories:
+  - visualization
+  - cell typing
 image: figures/smooth_foxp3_thumbnail.png
 description: "Applications for visualization and cell typing using 'smoothed' marker genes based on expression nearest neighbors"
 draft: false

--- a/posts/nanoU/index.qmd
+++ b/posts/nanoU/index.qmd
@@ -8,7 +8,8 @@ author:
       - ref: eveilyeverafter
 toc: false
 date: "2024-10-17"
-categories: [nanoU]
+categories:
+  - nanoU
 draft: false
 image: https://cc.sj-cdn.net/instructor/j3v0702q7qcg-nanostring-university/courses/3ppjfhs3ah3wf/promo-image.1728930731.png
 description: "NanoString University New Course Alert!"

--- a/posts/napari-cosmx-basics/using-napari-cosmx.qmd
+++ b/posts/napari-cosmx-basics/using-napari-cosmx.qmd
@@ -14,7 +14,11 @@ toc-location: left
 number-sections: true
 number-depth: 4
 date: "2024-06-17"
-categories: [napari, how-tos, visualization, python]
+categories:
+  - napari
+  - how-tos
+  - visualization
+  - python
 draft: false
 image: figures/fig-duality.png
 description: In this post, I walk through some of the basic 

--- a/posts/napari-cosmx-intro/index.qmd
+++ b/posts/napari-cosmx-intro/index.qmd
@@ -14,7 +14,10 @@ toc-location: left
 number-sections: true
 number-depth: 4
 date: "2024-05-01"
-categories: [visualization, napari, python]
+categories:
+  - visualization
+  - napari
+  - python
 draft: false
 image: figures/prostate.gif
 code-fold: true

--- a/posts/napari-rois/cosmx-rois.qmd
+++ b/posts/napari-rois/cosmx-rois.qmd
@@ -17,7 +17,13 @@ code-fold: false
 code-line-numbers: false
 code-overflow: scroll
 date: "2024-11-21"
-categories: [napari, how-tos, python, ROIs, subsetting, insitutype]
+categories:
+  - napari
+  - how-tos
+  - python
+  - ROIs
+  - subsetting
+  - insitutype
 draft: false
 image: figures/fig-initial.png
 description: This post shows you how to manually select ROIs in python to enhance your 

--- a/posts/napari-stitching/napari-cosmx-stitching.qmd
+++ b/posts/napari-stitching/napari-cosmx-stitching.qmd
@@ -17,16 +17,13 @@ code-fold: false
 code-line-numbers: false
 code-overflow: scroll
 date: "2024-10-18"
-categories: [napari, how-tos, python]
+categories:
+  - napari
+  - how-tos
+  - python
 draft: false
 image: figures/fig-stitch-single-slide.png
 description: Did you know that napari-cosmx can stitch images from AtoMx&#8482; SIP programmatically? In this post I show users who are comfortable with scripting how to stitch without directly using napari's GUI.
-# page-layout: full
-format: 
-  html:
-    theme: 
-      light: custom.scss
-      dark: darkly
 google-scholar: true
 ---
 

--- a/posts/normalization/index.qmd
+++ b/posts/normalization/index.qmd
@@ -8,7 +8,10 @@ author:
       - ref: patrickjdanaher
 date: "2024-01-29"
 date-modified: "2024-06-19"
-categories: [quality control, normalization, pre-processing]
+categories:
+  - quality control
+  - normalization
+  - pre-processing
 draft: false
 image: figures/puzzle.png
 ---

--- a/posts/on-cell-typing-with-marker-genes/index.qmd
+++ b/posts/on-cell-typing-with-marker-genes/index.qmd
@@ -8,7 +8,8 @@ author:
       - ref: patrickjdanaher
 date: "2024-03-12"
 date-modified: "2024-04-17"
-categories: [cell typing]
+categories:
+  - cell typing
 draft: false
 ---
 

--- a/posts/rss/index.qmd
+++ b/posts/rss/index.qmd
@@ -14,7 +14,8 @@ toc-location: left
 number-sections: true
 number-depth: 4
 date: "2024-10-17"
-categories: [rss]
+categories:
+  - rss
 draft: false
 image: figures/rss-thumbnail.jpeg
 description: "Don't miss a post! This post shows you how to get automatic updates when there's a new post."

--- a/posts/segmentation-error-evaluation/index.qmd
+++ b/posts/segmentation-error-evaluation/index.qmd
@@ -15,7 +15,9 @@ number-sections: true
 number-depth: 4
 date: "2024-05-15"
 date-modified: last-modified
-categories: [segmentation, algorithms]
+categories:
+  - segmentation
+  - algorithms
 image: figures/Fig1-FastReseg-workflow.png
 description: "FastReseg algorithm scores individual transcripts for the goodness-of-fit within their respective cells based on the probability of each gene belonging to each cell type and the spatial dependency of transcript score. FastReseg can flag cells with putative cell segmentation errors and perform corrections rapidly. "
 draft: false

--- a/posts/segmentation-error/index.qmd
+++ b/posts/segmentation-error/index.qmd
@@ -8,7 +8,8 @@ author:
       - ref: patrickjdanaher
 date: "2024-01-24"
 date-modified: "2024-04-17"
-categories: [segmentation]
+categories:
+  - segmentation
 draft: false
 ---
 

--- a/posts/seurat-cosmx-basics/index.qmd
+++ b/posts/seurat-cosmx-basics/index.qmd
@@ -15,7 +15,9 @@ number-sections: true
 number-depth: 4
 date: "2024-05-10"
 date-modified: last-modified
-categories: [visualization, Seurat]
+categories:
+  - visualization
+  - Seurat
 image: figures/plot_oneCosMxFOV-1.png
 description: "Recommendations for spatial plots in Seurat"
 draft: false

--- a/posts/spatial-algorithm-zoo/index.qmd
+++ b/posts/spatial-algorithm-zoo/index.qmd
@@ -13,7 +13,8 @@ toc-expand: 2
 toc-location: left
 date: "2024-03-20"
 date-modified: "2024-04-17"
-categories: [algorithms]
+categories:
+  - algorithms
 draft: false
 ---
 

--- a/posts/squidpy-essentials/squidpy-essentials.qmd
+++ b/posts/squidpy-essentials/squidpy-essentials.qmd
@@ -14,7 +14,11 @@ toc-location: left
 number-sections: true
 number-depth: 3
 date: "2024-07-03"
-categories: [Squidpy, python, visualization, AnnData]
+categories:
+  - Squidpy
+  - python
+  - visualization
+  - AnnData
 draft: false
 image: figures/fig-image1.png
 description: In this blog post, I’ll show how to prepare and analyze AtoMx&#8482; SIP-exported CosMx<sup>&#174;</sup> SMI data with python\'s squidpy package.

--- a/posts/vignette-basic-analysis/index.qmd
+++ b/posts/vignette-basic-analysis/index.qmd
@@ -13,7 +13,13 @@ toc-expand: 2
 toc-location: left
 date: "2024-05-24"
 date-modified: "2024-05-24"
-categories: [recommended, overview, quality control, normalization, cell typing, pre-processing]
+categories:
+  - recommended
+  - overview
+  - quality control
+  - normalization
+  - cell typing
+  - pre-processing
 draft: false
 ---
 

--- a/posts/visualize-cellular-neighborhood-in-gallery-mode/index.qmd
+++ b/posts/visualize-cellular-neighborhood-in-gallery-mode/index.qmd
@@ -13,7 +13,9 @@ author:
       - ref: patrickjdanaher
 date: "2024-01-24"
 date-modified: "2024-04-17"
-categories: [visualization, napari]
+categories:
+  - visualization
+  - napari
 draft: false
 image: figures/fig6.png
 ---

--- a/posts/visuals-reduce-whitespace/index.qmd
+++ b/posts/visuals-reduce-whitespace/index.qmd
@@ -8,7 +8,8 @@ author:
       - ref: patrickjdanaher
 date: "2024-01-26"
 date-modified: "2024-04-17"
-categories: [visualization]
+categories:
+  - visualization
 draft: false
 image: figures/fig2.png
 ---


### PR DESCRIPTION
When the cats were listed [within, a, list, like, this], quarto (new version?) switched to base64 encoded URLs which caused an error when viewing and filtering based on those tags. 