### PR TITLE
151 installing insitutree

### DIFF
--- a/_code/InSituTree/README.md
+++ b/_code/InSituTree/README.md
@@ -10,9 +10,10 @@ being assessed.
 ## Installation
 
 ```
-devtools::install_github("https://github.com/Nanostring-Biostats/CosMx-Analysis-Scratch-Space/tree/Main/_code/InSituTree")
+devtools::install_github("https://github.com/Nanostring-Biostats/CosMx-Analysis-Scratch-Space", 
+    subdir="_code/InSituTree")
 ```
 
 ## Usage:
 
-See the vignette.   
+See the vignette.

--- a/_code/InSituTree/README.md
+++ b/_code/InSituTree/README.md
@@ -10,7 +10,7 @@ being assessed.
 ## Installation
 
 ```
-devtools::install_github("https://github.com/Nanostring-Biostats/CosMx-Analysis-Scratch-Space", 
+devtools::install_github("https://github.com/Nanostring-Biostats/CosMx-Analysis-Scratch-Space",
     subdir="_code/InSituTree")
 ```
 


### PR DESCRIPTION
The installation command for `InSituTree` on the README page was incorrectly formatted, missing this package as a subdirectory; this PR updates that command. This PR fixes #151.