### PR TITLE
added quick fix for dark mode code text

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -36,7 +36,7 @@ format:
   html:
     theme: 
       light: custom.scss
-      dark: darkly
+      dark: [darkly, theme-dark.scss]
 
 
 

--- a/theme-dark.scss
+++ b/theme-dark.scss
@@ -1,0 +1,9 @@
+/*-- scss:rules --*/
+
+/* Adjusts the color of inline code snippets */
+code {
+    color: #ffd700 !important; 
+    background-color: #333 !important; 
+    padding: 2px 4px;
+    border-radius: 4px;
+}


### PR DESCRIPTION
This closes #205 

This makes it easier to see code blocks in dark mode by adjusting the theme so that there is yellow font on dark background (see image below)

<img width="714" height="465" alt="image" src="https://github.com/user-attachments/assets/b5ac76eb-572d-43f7-827d-720555a80ce5" />
