### PR TITLE
Hieratype bugfix

### DIFF
--- a/R/clusterwise_foldchange_metrics.R
+++ b/R/clusterwise_foldchange_metrics.R
@@ -38,6 +38,7 @@ clusterwise_foldchange_metrics <- function(counts=NULL, normed = NULL, totalcoun
               length(unique(metainfo[["cell_ID"]])) == nrow(metainfo))
   
   if(!is.null(counts)){
+    ## checks on the counts matrix 
     if(!is.null(totalcounts)){
       stopifnot(length(totalcounts) == ncol(counts))
       if(!is.null(names(totalcounts)) && !is.null(colnames(counts))){
@@ -45,17 +46,30 @@ clusterwise_foldchange_metrics <- function(counts=NULL, normed = NULL, totalcoun
                     all(names(totalcounts) %in% colnames(counts))) 
         totalcounts <- totalcounts[colnames(counts)] 
       }
+      if(is.null(names(totalcounts))){
+        warning("No names provided for 'totalcounts'.\nAssuming that 'totalcounts' vector matches the order of provided 'counts' matrix.\nPlease consider providing a cellid-named vector of totalcounts.")
+      }
+    }
+    stopifnot(all(metainfo[["cell_ID"]] %in% colnames(counts)))
+    if(nrow(metainfo)!=ncol(counts)){
+      warning("Number of rows (cells) in 'metadata' does not match the number of columns (cells) in the 'counts' matrix!\nUsing only the cells in the metadata to compute the foldchange table.")
     }
   }  else {
     if(missing(normed)){
         stop("either 'normed' or 'counts' argument must be provided")
     }
   }
-   
+  
   if(missing(normed)){
     normed <- Matrix::t(totalcount_norm(Matrix::t(counts), totalcounts))
   }
  
+  ## check on the normed matrix 
+  stopifnot(all(metainfo[["cell_ID"]] %in% colnames(normed)))
+  if(nrow(metainfo)!=ncol(normed)){
+    warning("Number of rows (cells) in 'metadata' does not match the number of columns (cells) in the 'normed' matrix!\nUsing only the cells in the metadata to compute the foldchange table.")
+  }
+  
   
   pb <- txtProgressBar(min =0, max = length(unique(metainfo[[cluster_column]])), style = 3)
   idx <- 0

--- a/R/clusterwise_foldchange_metrics.R
+++ b/R/clusterwise_foldchange_metrics.R
@@ -22,7 +22,6 @@
 #' @export
 clusterwise_foldchange_metrics <- function(counts=NULL, normed = NULL, totalcounts = NULL, metadata, cluster_column, cellid_column = "cell_ID"){
 
-  stopifnot(cellid_column %in% colnames(metadata)) 
   stopifnot(cluster_column %in% colnames(metadata)) 
   metainfo <- data.table::copy(data.table::data.table(metadata))
   if(!(cellid_column) %in% colnames(metainfo)){

--- a/R/clusterwise_foldchange_metrics.R
+++ b/R/clusterwise_foldchange_metrics.R
@@ -21,12 +21,21 @@
 #' 
 #' @export
 clusterwise_foldchange_metrics <- function(counts=NULL, normed = NULL, totalcounts = NULL, metadata, cluster_column, cellid_column = "cell_ID"){
- 
+
   stopifnot(cellid_column %in% colnames(metadata)) 
   stopifnot(cluster_column %in% colnames(metadata)) 
   metainfo <- data.table::copy(data.table::data.table(metadata))
+  if(!(cellid_column) %in% colnames(metainfo)){
+    stopifnot(!is.null(rownames(metadata)))
+    cellid_column <- "cell_ID"
+    metainfo[[cellid_column]] <- rownames(metadata)
+  }
+  if(cellid_column!="cell_ID" & ("cell_ID" %in% names(metainfo))) metainfo[["cell_ID"]] <- NULL
+  data.table::setnames(metainfo, old=cellid_column, new="cell_ID")
+  rm(metadata); gc()
+  
   stopifnot("provided 'cellid_column' are not all unique in metadata " = 
-              length(unique(metainfo[[cellid_column]])) == nrow(metainfo))
+              length(unique(metainfo[["cell_ID"]])) == nrow(metainfo))
   
   if(!is.null(counts)){
     if(!is.null(totalcounts)){


### PR DESCRIPTION
Some tests I ran to ensure 'cellid_column' arguemnt is handled as expected

The change here is that we create the column called "cell_ID" at the beginning of the function after copying metadata, so we can assume that column name throughout the rest of the function

```
## uses 'cell_ID' by default
fc1 <- clusterwise_foldchange_metrics(counts = gem@expression$rna$raw
                                      ,metadata = metainfo
                                      ,cluster_column = "cell_type_all"
                                      # ,cellid_column = "abc"
)

## duplicated cell_ID (fails)
metainfo[,cell_Id2:=sample(cell_ID,.N,replace=TRUE)]
fc2 <- clusterwise_foldchange_metrics(counts = gem@expression$rna$raw
                                      ,metadata = metainfo
                                      ,cluster_column = "cell_type_all"
                                      ,cellid_column = "cell_Id2"
)

## non-duplicated cell_ID, it runs but results don't match fc1 (uses cell_Id3)
metainfo[,cell_Id3:=sample(cell_ID,.N,replace=FALSE)]
fc3 <- clusterwise_foldchange_metrics(counts = gem@expression$rna$raw
                                      ,metadata = metainfo
                                      ,cluster_column = "cell_type_all"
                                      ,cellid_column = "cell_Id3"
)

## column doesn't exist, function fails
fc3 <- clusterwise_foldchange_metrics(counts = gem@expression$rna$raw
                                      ,metadata = metainfo
                                      ,cluster_column = "cell_type_all"
                                      ,cellid_column = "cell_Id_noexist"
)



```