### PR TITLE
Hieratype pr bugfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: HieraType
 Title: Package for Hierarchical Cell Typing using Smoothed Metagene Scores
-Version: 1.0.0.0
+Version: 1.0.1
 Authors@R: 
     person("Dan", "McGuire", , "daniel.mcguire@bruker.com", role = c("aut", "cre"))
 Description: Package for cell typing using smoothed metagene scores.

--- a/R/combine_postprob_tables.R
+++ b/R/combine_postprob_tables.R
@@ -33,7 +33,7 @@ combine_postprob_tables <- function(pipeline
     while(length(child_categories) > 0){
       child_categories_new <- c()
       for(chld in child_categories){
-        post_probsl[[parnt]] <- merge(post_probsl[[parnt]], models[[chld]]$post_probs, by = "cell_ID")
+        post_probsl[[parnt]] <- merge(post_probsl[[parnt]], models[[chld]]$post_probs, by = "cell_ID", sort = FALSE)
         #post_probsl[[parnt]][best_score > celltype_call_threshold,celltype_thresh:=best_class]
         whch_threshold <- post_probsl[[parnt]][best_score > celltype_call_threshold,which=TRUE]
         parnt_cat <- pipeline$priors_category[[chld]]

--- a/R/run_pipeline.R
+++ b/R/run_pipeline.R
@@ -41,7 +41,7 @@ run_pipeline <- function(pipeline, counts_matrix
                  ,c(list(markerslist = pipeline$markerslist[[parnt]]
                          ,counts_matrix = counts_matrix
                          ,adjacency_matrix = adjacency_matrix
-                         ,prior_level_wts = initial_prior_weights
+                         ,prior_level_weights = initial_prior_weights
                          )
                     ,dots[names(dots) %in% names(formals(fit_metagene_scores))]
                     )
@@ -69,7 +69,7 @@ run_pipeline <- function(pipeline, counts_matrix
                  ,c(list(markerslist = pipeline$markerslist[[chld]]
                          ,counts_matrix = counts_matrix
                          ,adjacency_matrix = adjacency_matrix
-                         ,prior_level_wts = prior_wts
+                         ,prior_level_weights = prior_wts
                          )
                     ,dots[names(dots) %in% names(formals(fit_metagene_scores))]
                     )


### PR DESCRIPTION
Fix typos in run_pipeline arguments, and don't sort by cell id in `combine_postprob_tables` (maintain cell order matching the counts matrix).  