### PR TITLE
add links to new analysis vignette

### DIFF
--- a/about.qmd
+++ b/about.qmd
@@ -46,7 +46,7 @@ If you would like to see a blog post on a particular topic, submit an issue on o
 
 - [X] [What is spatial data for?](posts/high-plex-spatial/index.qmd)
 - [X] [Vignette: basics of CosMx<sup>&#174;</sup> analysis in R (circa 2023, deprecated)](posts/vignette-basic-analysis/index.qmd)
-- [X] [Vignette: basics of CosMx<sup>&#174;</sup> analysis in R](posts/vignette-basic-analysis-updated/index.qmd)
+- [X] [Vignette: basics of CosMx<sup>&#174;</sup> analysis in R](posts/vignette-basic-analysis-updated/01_preprocessing.qmd)
 - [X] [Using Squidpy with AtoMx<sup>&#174;</sup> SIP exports](posts/squidpy-essentials/squidpy-essentials.qmd)
 - [X] [QC and normalization of RNA data](posts/normalization/index.qmd)
 - [X] [FOV QC from single-cell gene expression in spatial dataset](posts/fov-qc/index.qmd)

--- a/posts/vignette-basic-analysis/index.qmd
+++ b/posts/vignette-basic-analysis/index.qmd
@@ -12,7 +12,7 @@ toc-depth: 3
 toc-expand: 2
 toc-location: left
 date: "2024-05-24"
-date-modified: "2024-05-24"
+date-modified: "2026-01-08"
 categories:
   - recommended
   - overview
@@ -24,6 +24,15 @@ draft: false
 ---
 
 # Basic CosMx analysis workflow
+
+::: {.callout-tip}
+## Updated vignette available
+
+As of December 2025, we have an updated RNA analysis vignette available in
+three parts on our blog, starting
+[here](../vignette-basic-analysis-updated/01_preprocessing.qmd).
+
+:::
 
 ## Introduction
 


### PR DESCRIPTION
This PR adds a small link to our original (2024) basic analysis workflow pointing users to the updated (Dec 2025) posts. It also fixes a link from our table of contents to the new workflow post.