### PR TITLE
Bug/hieratype discourage double pos argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: HieraType
 Title: Package for Hierarchical Cell Typing using Smoothed Metagene Scores
-Version: 1.0.3
+Version: 1.0.4
 Authors@R: 
     person("Dan", "McGuire", , "daniel.mcguire@bruker.com", role = c("aut", "cre"))
 Description: Package for cell typing using smoothed metagene scores.

--- a/R/cluster_metagenes.R
+++ b/R/cluster_metagenes.R
@@ -96,8 +96,9 @@ cluster_metagenes <- function(metagenes = NULL
     if(!fit_single_positive_only){
       criteria_2 <- (npos.2==1 & conds[,ii]==1) ## passes prior_prob_level threshold and yhat > 0 and ypost(erior) > 0
       if(!is.null(discourage_double_positive[[ii]])){
-        if(discourage_double_positive[[ii]] %in% colnames(yp)){
-          double_pos_pass_yhat <- apply(yp[,discourage_double_positive[[ii]],drop=FALSE] > 0, 1, mean) ## check if posterior scores for forbidden cell types are > 0
+        if(any(discourage_double_positive[[ii]] %in% colnames(yp))){
+          otherct <- intersect(discourage_double_positive[[ii]],colnames(yp))
+          double_pos_pass_yhat <- apply(yp[,otherct,drop=FALSE] > 0, 1, mean) ## check if posterior scores for forbidden cell types are > 0
           double_pos_pass <- double_pos_pass_yhat==0  ## if none of the forbidden celltypes have posterior scores > 0, then the cell passes
           criteria_2 <- criteria_2 & double_pos_pass  
         } else {


### PR DESCRIPTION
This is a small bug fix for the discourage_double_positive argument in 
`HieraType::cluster_metagenes()`

Previous code prevented multiple celltypes from being discouraged.
i.e.,
```
cluster_metagenes(
...,
discourage_double_positive = list(
plasma = c("immune", "epithelial"))
)
```
This argument should exclude plasma anchor cells which have  positive immune and/or epithelial metagene scores.

This currently works with a single celltype, but not both. This fix allows multiple celltypes to be specified.
